### PR TITLE
Adjust time for tags

### DIFF
--- a/pocketmon.py
+++ b/pocketmon.py
@@ -43,10 +43,10 @@ def reading_time(minutes):
         return '%d minutes' % rounded
     elif 50 <= rounded < 75:
         return '1 hour'
-    elif 75 <= rounded < 90:
+    elif 75 <= rounded < 105:
         return '1.5 hours'
     else:
-        return '2 hours'
+        return '2+ hours'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Modify accepted reading times for "1.5 hours" tag to include
  articles up to 105 minutes.
- Make tag for articles over 105 minutes "2+ hours" as opposed to
  "2 hours"
